### PR TITLE
 連絡先の削除 ContactsController.phpのdestroyメソッドの実装とapi.phpに@destroyの追記、ContactsTest.phpにcontactsテーブルのデータを空できているかアサーションを追加

### DIFF
--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -23,6 +23,11 @@ class ContactsController extends Controller
         $contact->update($this->validateData());
     }
 
+    public function destroy(Contact $contact)
+    {
+        $contact->delete();
+    }
+
     public function validateData()
     {
         return request()->validate([

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,3 +20,4 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::post('/contacts', 'ContactsController@store');
 Route::get('/contacts/{contact}', 'ContactsController@show');
 Route::patch('/contacts/{contact}', 'ContactsController@update');
+Route::delete('/contacts/{contact}', 'ContactsController@destroy');

--- a/tests/Feature/ContactsTest.php
+++ b/tests/Feature/ContactsTest.php
@@ -99,6 +99,13 @@ class ContactsTest extends TestCase
         $this->assertEquals('ABC String', $contact->company);
     }
 
+    public function a_contact_can_be_deleted()
+    {
+        $contact = factory(Contact::class)->create();
+        $response = $this->delete('/api/contacts/' . $contact->id);
+        $this->assertCount(0, Contact::all());
+    }
+
     private function data()
     {
         return [


### PR DESCRIPTION
ContactsTest.phpにa_contact_can_be_deleted()メソッドを書いて、contactsテーブルのデータを空できているかテストを書き、グリーンにした。api.phpにも、Route::delete('/contacts/{contact}', 'ContactsController@destroy'); を追記。