### PR TITLE
認証されたユーザーの連絡先のリストを取得できるかのテスト ContactsTest.php

### DIFF
--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -8,6 +8,11 @@ use Illuminate\Http\Request;
 class ContactsController extends Controller
 {
     //
+    public function index()
+    {
+        return request()->user()->contacts;
+    }
+
     public function store()
     {
         Contact::create($this->validateData());

--- a/app/User.php
+++ b/app/User.php
@@ -26,4 +26,9 @@ class User extends Authenticatable
     protected $hidden = [
         'password', 'remember_token',
     ];
+
+    public function contacts()
+    {
+        return $this->hasMany(Contact::class);
+    }
 }

--- a/database/migrations/2019_12_07_024731_create_contacts_table.php
+++ b/database/migrations/2019_12_07_024731_create_contacts_table.php
@@ -15,6 +15,7 @@ class CreateContactsTable extends Migration
     {
         Schema::create('contacts', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->string('email');
             $table->timestamp('birthday');

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 */
 
 Route::middleware('auth:api')->group(function() {
+    Route::get('/contacts', 'ContactsController@index');
     Route::post('/contacts', 'ContactsController@store');
     Route::get('/contacts/{contact}', 'ContactsController@show');
     Route::patch('/contacts/{contact}', 'ContactsController@update');

--- a/tests/Feature/ContactsTest.php
+++ b/tests/Feature/ContactsTest.php
@@ -19,7 +19,24 @@ class ContactsTest extends TestCase
         parent::setUp();
         $this->user = factory(User::class)->create();
     }
-    
+
+    /**
+     * @test
+     * ユーザーに関連づけられているものを削除、表示および編集する。
+     * 認証されたユーザーの連絡先のリストを取得できるかのテスト。
+     */
+    public function a_list_of_contacts_can_be_fetched_for_the_authenticated_user()
+    {
+        $user = factory(User::class)->create();
+        $anotherUser = factory(User::class)->create();
+
+        $contact = factory(Contact::class)->create(['user_id' => $user->id]);
+        $anotherContact = factory(Contact::class)->create(['user_id' => $anotherUser->id]);
+
+        $response = $this->get('/api/contacts?api_token=' . $user->api_token);
+
+        $response->assertJsonCount(1)->assertJson([['id' => $contact->id]]);
+    }
     /** @test
      *
      */


### PR DESCRIPTION
a_list_of_contacts_can_be_fetched_for_the_authenticated_user()メソッドの追加をして、
ユーザーに関連づけられているものを削除、表示および編集することができるようにするために、
認証されたユーザーの連絡先のリストを取得できるかのテストを実装した。
a_list_of_contacts_can_be_fetched_for_the_authenticated_user()メソッド自体はグリーンになったが、
他のメソッドがエラーが出ているので、修正する必要あり。
contactsテーブルに、'user_id'カラムを追加する処理を記載し、$table->unsignedBigInteger('user_id'); のようにした。


### 以下をContactsTest.php に追加
```
// 以下をContactsTest.php に追加

public function a_list_of_contacts_can_be_fetched_for_the_authenticated_user()
    {
        $user = factory(User::class)->create();
        $anotherUser = factory(User::class)->create();

        $contact = factory(Contact::class)->create(['user_id' => $user->id]);
        $anotherContact = factory(Contact::class)->create(['user_id' => $anotherUser->id]);

        $response = $this->get('/api/contacts?api_token=' . $user->api_token);

        $response->assertJsonCount(1)->assertJson([['id' => $contact->id]]);
    }
```

### User.php に以下を追加
```
// User.php に以下を追加

public function contacts()
    {
        return $this->hasMany(Contact::class);
    }
```

### ContactsController.php に以下を追加
```
public function index()
    {
        return request()->user()->contacts;
    }
```

### api.php の Route::middleware('auth:api')->group(function() { の中に以下を追加
```
// api.php の Route::middleware('auth:api')->group(function() { の中に以下を追加
Route::get('/contacts', 'ContactsController@index');
```