### PR TITLE
ContactsTest.php ← 修正

### DIFF
--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Contact;
+use App\Http\Resources\Contact as ContactResource;
 use Illuminate\Http\Request;
 
 class ContactsController extends Controller
@@ -11,7 +12,7 @@ class ContactsController extends Controller
     public function index()
     {
         $this->authorize('create', Contact::class);
-        return request()->user()->contacts;
+        return ContactResource::collection(request()->user()->contacts);
     }
 
     public function store()
@@ -23,7 +24,7 @@ class ContactsController extends Controller
     public function show(Contact $contact)
     {
         $this->authorize('view', $contact);
-        return $contact;
+        return new ContactResource($contact);
     }
 
     public function update(Contact $contact)

--- a/app/Http/Resources/Contact.php
+++ b/app/Http/Resources/Contact.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\Resource;
+
+class Contact extends Resource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'contact_id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'birthday' => $this->birthday->format('m/d/Y'),
+            'company' => $this->company,
+            'last_updated' => $this->updated_at->diffForHumans(),
+        ];
+    }
+}

--- a/tests/Feature/ContactsTest.php
+++ b/tests/Feature/ContactsTest.php
@@ -35,7 +35,11 @@ class ContactsTest extends TestCase
 
         $response = $this->get('/api/contacts?api_token=' . $user->api_token);
 
-        $response->assertJsonCount(1)->assertJson([['id' => $contact->id]]);
+        $response->assertJsonCount(1)->assertJson([
+            'data' => [
+                ['contact_id' => $contact->id],
+            ]
+        ]);
     }
     /** @test
      *
@@ -113,10 +117,14 @@ class ContactsTest extends TestCase
         $contact = factory(Contact::class)->create(['user_id' => $this->user->id]);
         $response = $this->get('/api/contacts/' . $contact->id . '?api_token=' . $this->user->api_token);
         $response->assertJson([
-            'name' => $contact->name,
-            'email' => $contact->email,
-            'birthday' => $contact->birthday,
-            'company' => $contact->company,
+            'data' => [
+                'contact_id' => $contact->id,
+                'name' => $contact->name,
+                'email' => $contact->email,
+                'birthday' => $contact->birthday->format('m/d/Y'),
+                'company' => $contact->company,
+                'last_updated' => $contact->updated_at->diffForHumans(),
+            ]
         ]);
     }
 


### PR DESCRIPTION
ContactsController.php ← 修正

app/Http/Resources/Contact.php を 

```
php artisan make:resource Contact  // ←のコマンドで追加
```

現在は、API に不要なものも含まれている。また、人が読むのに適した形式になっているとは言い難いので、修正する必要あり。return させて、jsonを直接viewに渡すのではなく、resource を作り、ここで整形しやすい形に変換してあげるようにする。

app/Http/Controllers/ContactsController.php
```
public function index()
    {
        $this->authorize('create', Contact::class);
        return request()->user()->contacts;
        return ContactResource::collection(request()->user()->contacts);  // collection() を使用している。
    }
```

app/Http/Resources/Contact.php
```
<?php
namespace App\Http\Resources;
use Illuminate\Http\Resources\Json\Resource;
class Contact extends Resource
{
    /**
     * Transform the resource into an array.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return array
     */
    public function toArray($request)
    {
        return [
            'contact_id' => $this->id,
            'name' => $this->name,
            'email' => $this->email,
            'birthday' => $this->birthday->format('m/d/Y'),
            'company' => $this->company,
            'last_updated' => $this->updated_at->diffForHumans(),
        ];
    }
}
```

