### PR TITLE
ContactsController.php の update() メソッド と delete() メソッドを中心に正しいステータスレスポンスを実装した。

### DIFF
--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -35,12 +35,16 @@ class ContactsController extends Controller
     {
         $this->authorize('update', $contact);
         $contact->update($this->validateData());
+        return (new ContactResource($contact))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
     }
 
     public function destroy(Contact $contact)
     {
         $this->authorize('delete', $contact);
         $contact->delete();
+        return response([], Response::HTTP_NO_CONTENT);
     }
 
     public function validateData()

--- a/tests/Feature/ContactsTest.php
+++ b/tests/Feature/ContactsTest.php
@@ -38,8 +38,12 @@ class ContactsTest extends TestCase
 
         $response->assertJsonCount(1)->assertJson([
             'data' => [
-                ['contact_id' => $contact->id],
-            ],
+                [
+                    'data' => [
+                        'contact_id' => $contact->id,
+                    ],
+                ]
+            ]
         ]);
     }
     /** @test
@@ -72,7 +76,7 @@ class ContactsTest extends TestCase
                 'contact_id' => $contact->id,
             ],
             'links' => [
-                'self' => url('/contacts/' . $contact->id),
+                'self' => $contact->path(),
             ],
         ]);
     }
@@ -161,6 +165,15 @@ class ContactsTest extends TestCase
         $this->assertEquals('test@email.com', $contact->email);
         $this->assertEquals('05/14/1988', $contact->birthday->format('m/d/Y'));
         $this->assertEquals('ABC String', $contact->company);
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJson([
+            'data' => [
+                'contact_id' => $contact->id,
+            ],
+            'links' => [
+                'self' => $contact->path(),
+            ],
+        ]);
     }
 
     /**
@@ -179,6 +192,7 @@ class ContactsTest extends TestCase
         $contact = factory(Contact::class)->create(['user_id' => $this->user->id]);
         $response = $this->delete('/api/contacts/' . $contact->id, ['api_token' => $this->user->api_token]);
         $this->assertCount(0, Contact::all());
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
     }
 
     /**


### PR DESCRIPTION
ContactsController.php の update() メソッド と delete() メソッドを中心に正しいステータスレスポンスを実装した。
ContactsTest.php の a_contact_can_be_patched() メソッドのステータスコードも Response::HTTP_OK とする等、Httpレスポンスに関する修正を行った。