### PR TITLE
Authディレクトリ配下の4つのControllerで、"/home" となっているところを "/" として、ログイン先を "/home"…

### DIFF
--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -13,7 +13,7 @@ class AppController extends Controller
      */
     public function __construct()
     {
-//        $this->middleware('auth');
+        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -25,7 +25,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -27,7 +27,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.
@@ -66,6 +66,7 @@ class RegisterController extends Controller
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => bcrypt($data['password']),
+            'api_token' => str_random(32),
         ]);
     }
 }

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -25,7 +25,7 @@ class ResetPasswordController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.

--- a/app/User.php
+++ b/app/User.php
@@ -15,7 +15,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'name', 'email', 'password', 'api_token',
     ];
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,4 +2,8 @@
 
 Auth::routes();
 
+Route::get("/logout-manual", function() {
+    request()->session()->invalidate();
+});
+
 Route::get('/{any}', 'AppController@index')->where('any', '.*');


### PR DESCRIPTION
#27 RegisterController.php に api_token の認証情報を追加しつつ、
Authディレクトリ配下の4つのControllerで、"/home" となっているところを "/" として、ログイン先を "/home" から "/" へ変更した。

auth の middleware するべく、AppController.php の16行目のコメントアウトになっている、コンストラクタの$this->middleware('auth');復帰させ、auth の middleware を適用させた。

ログアウトできているかブラウザから目視でわかりにくいので、
web.php に、下記のコードを書き、ログアウトできるようにした。
```PHP
Route::get("/logout-manual", function() {
    request()->session()->invalidate();
});
```
#27